### PR TITLE
Delete Game object after simulating

### DIFF
--- a/simulator/view_tests/test_game_views.py
+++ b/simulator/view_tests/test_game_views.py
@@ -62,7 +62,4 @@ class GameViewTest(TestCase):
 
         response = self.client.post(f'/api/sim-game', {"id": g.id})
 
-        updated_g = Game.objects.get(id=g.id)
-
-
-        self.assertTrue(updated_g.completed)
+        self.assertTrue('winner' in response.data)

--- a/simulator/views.py
+++ b/simulator/views.py
@@ -82,9 +82,11 @@ def sim_game(request, *args, **kwargs):
     except:
         return Response({"Unable to run game"}, status=400)
 
-    # print(obj.serialize())
+    game_data = obj.serialize()
 
-    return Response(obj.serialize(), content_type='application/javascript')
+    obj.delete()
+
+    return Response(game_data, content_type='application/javascript')
 
 @api_view(['GET'])
 def get_relationshops(request, *args, **kwargs):


### PR DESCRIPTION
Before, games weren't getting deleted after being simulated, so the database was filling with unnecessary game objects. Now, game objects will be deleted immediately after simulation.

fixes #23 